### PR TITLE
Windows support, and some changes to the Android and iOS code

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Apache Cordova
+Copyright 2012 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
-Apache Cordova
+cordova-plugin-thumbnail
 Copyright 2012 The Apache Software Foundation
 
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+This software contains code derived from the cordova-plugin-file library (version 6.0.1).
+cordova-plugin-file is released under the Apache License version 2 (see LICENSE-APACHE file).

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 cordova-plugin-thumbnail
-Copyright 2012 The Apache Software Foundation
+Copyright 2018 The Apache Software Foundation
 
 This software contains code derived from the cordova-plugin-file library (version 6.0.1).
 cordova-plugin-file is released under the Apache License version 2 (see LICENSE-APACHE file).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cordova-plugin-thumbnail
 
-This plug-in implements the ability to generate image thumbnails for Cordova project. Support Android and iOS.
+This plug-in implements the ability to generate image thumbnails for Cordova project. Support Android, iOS, and Windows.
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ cordova plugin add https://github.com/almas/cordova-plugin-thumbnail.git
   - `maxPixelSize`: Maximum width or height of thumbnail in pixels (default value: 120)
   - `targetPath` Thumbnail path. If not specified, will randomly create a file to store the generated thumbnail.
   - `compression` The quality of the resulting image, expressed as a value from 0 to 100. The value 0 represents the maximum compression (or lowest quality) while the value 100 represents the least compression (or best quality). (default value: 90)
+  - `outputFormat` The format that the thumbnail will be generated in, valid options being PNG and JPG. (default format: JPG)
 - `successCallbackFn` Thumbnail generates a successful callback function
 - `failCallbackFn` Thumbnail Generation Failed Callback Function
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cordova-plugin-thumbnail",
-    "version": "1.0.0",
+    "version": "1.0.0-j5.1",
     "description": "Image thumbnail generator for Cordova project",
     "cordova": {
         "id": "cordova-plugin-thumbnail",

--- a/plugin.xml
+++ b/plugin.xml
@@ -43,4 +43,11 @@
         <framework src="CoreImage.framework"/>
         <framework src="ImageIO.framework"/>
     </platform>
+
+    <!-- windows -->
+    <platform name="windows">
+        <js-module src="src/windows/ThumbnailProxy.js" name="ThumbnailProxy">
+            <merges target="" />
+        </js-module>
+    </platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-thumbnail" version="1.0.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-thumbnail" version="1.0.0-j5.1">
     <name>Thumbnail</name>
     <description>Cordova Thumbnail Plugin</description>
     <license>Apache 2.0</license>

--- a/src/android/Thumbnails.java
+++ b/src/android/Thumbnails.java
@@ -82,7 +82,7 @@ public class Thumbnails {
             // File targetFile = new File(targetPath);
             // targetFile.createNewFile();
             os = new BufferedOutputStream(new FileOutputStream(targetPath));
-            bitmap.compress(guessImageType(targetPath), 90, os);
+            bitmap.compress(getOutputFormat(thumbnailOptions), 90, os);
         } catch (FileNotFoundException ex) {
             throw new TargetPathNotFoundException(ex);
         } catch (IOException ex) {
@@ -102,11 +102,10 @@ public class Thumbnails {
         return false;
     }
 
-    public static Bitmap.CompressFormat guessImageType(String filePath) {
-        String fileExt = filePath.substring(filePath.lastIndexOf(".") + 1).toLowerCase();
-        if (fileExt.equals("png")) {
+    public static Bitmap.CompressFormat getOutputFormat(Options thumbnailOptions) {
+        if (thumbnailOptions.outputFormat.equals("PNG")){
             return Bitmap.CompressFormat.PNG;
-        } else if (fileExt.equals("webp")) {
+        } else if (thumbnailOptions.outputFormat.equals("WEBP")) {
             return Bitmap.CompressFormat.WEBP;
         } else {
             return Bitmap.CompressFormat.JPEG;
@@ -116,6 +115,7 @@ public class Thumbnails {
     public static class Options {
         public String targetPath;
         public String sourcePath;
+        public String outputFormat;
         public int maxPixelSize;
         public int compression;
 

--- a/src/android/Thumbnails.java
+++ b/src/android/Thumbnails.java
@@ -79,8 +79,6 @@ public class Thumbnails {
         OutputStream os = null;
 
         try {
-            // File targetFile = new File(targetPath);
-            // targetFile.createNewFile();
             os = new BufferedOutputStream(new FileOutputStream(targetPath));
             bitmap.compress(getOutputFormat(thumbnailOptions), 90, os);
         } catch (FileNotFoundException ex) {

--- a/src/android/ThumbnailsCordovaPlugin.java
+++ b/src/android/ThumbnailsCordovaPlugin.java
@@ -93,6 +93,7 @@ public class ThumbnailsCordovaPlugin extends CordovaPlugin {
         boolean hasTargetPath = args.length() >= 3;
         Thumbnails.Options options = new Thumbnails.Options();
         options.sourcePath = args.getString(0).replace("file://", "");
+        options.outputFormat = args.getString(4);
         if (hasTargetPath) {
             options.targetPath = args.getString(1).replace("file://", "");
             options.maxPixelSize = args.getInt(2);

--- a/src/ios/Thumbnail.h
+++ b/src/ios/Thumbnail.h
@@ -9,7 +9,7 @@
 
 @interface Thumbnail : NSObject
 
-+ (void) thumbnail:(NSString *)imageURL size:(CGFloat)size toURL:(NSString *) toURL;
++ (void) thumbnail:(NSString *)imageURL size:(CGFloat)size toURL:(NSString *) toURL compression:(CGFloat)size outputFormat:(NSString *) outputFormat;
 
 @end
 

--- a/src/ios/Thumbnail.m
+++ b/src/ios/Thumbnail.m
@@ -137,6 +137,11 @@
             return;
         }
 
+        if([outputFormat isEqualToString:@"WEBP"]){
+            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"WEBP is not supported on iOS."];
+            [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+        }
+
         [FileUtil createFileAtURL: targetURL];
         [Thumbnail thumbnail:sourceURL size: size toURL:targetURL compression: compressionQuality outputFormat: outputFormat];
 

--- a/src/ios/Thumbnail.m
+++ b/src/ios/Thumbnail.m
@@ -139,7 +139,7 @@
 
         if([outputFormat isEqualToString:@"WEBP"]){
             CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"WEBP is not supported on iOS."];
-            [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+            [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
         }
 
         [FileUtil createFileAtURL: targetURL];

--- a/src/ios/Thumbnail.m
+++ b/src/ios/Thumbnail.m
@@ -133,10 +133,12 @@
 
         NSFileManager *fileManager = [NSFileManager defaultManager];
         if ([fileManager fileExistsAtPath:targetURL]) {
-            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Target file already exists."];
+            NSDictionary *message = @{@"code":@11,@"message": @"Target file already exists."};
+            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:message];
             [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
         } else if([outputFormat isEqualToString:@"WEBP"]){
-            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"WEBP is not supported on iOS."];
+            NSDictionary *message = @{@"code":@12,@"message": @"WEBP is not supported on iOS."};
+            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:message];
             [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
         } else {
             [FileUtil createFileAtURL: targetURL];

--- a/src/ios/Thumbnail.m
+++ b/src/ios/Thumbnail.m
@@ -133,23 +133,21 @@
 
         NSFileManager *fileManager = [NSFileManager defaultManager];
         if ([fileManager fileExistsAtPath:targetURL]) {
-            NSLog(@"Thumbnail file already exists %@", targetURL);
-            return;
-        }
-
-        if([outputFormat isEqualToString:@"WEBP"]){
+            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Target file already exists."];
+            [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+        } else if([outputFormat isEqualToString:@"WEBP"]){
             CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"WEBP is not supported on iOS."];
             [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+        } else {
+            [FileUtil createFileAtURL: targetURL];
+            [Thumbnail thumbnail:sourceURL size: size toURL:targetURL compression: compressionQuality outputFormat: outputFormat];
+
+            CDVPluginResult* pluginResult = nil;
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                             messageAsString:targetURL];
+
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         }
-
-        [FileUtil createFileAtURL: targetURL];
-        [Thumbnail thumbnail:sourceURL size: size toURL:targetURL compression: compressionQuality outputFormat: outputFormat];
-
-        CDVPluginResult* pluginResult = nil;
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                                         messageAsString:targetURL];
-
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
 }
 

--- a/src/ios/Thumbnail.m
+++ b/src/ios/Thumbnail.m
@@ -68,7 +68,7 @@
 
 @implementation Thumbnail
 
-+ (void) thumbnail:(NSString *)imageURL size:(CGFloat)maxSize toURL:(NSString *) toURL compression:(CGFloat) compressionQuality
++ (void) thumbnail:(NSString *)imageURL size:(CGFloat)maxSize toURL:(NSString *) toURL compression:(CGFloat) compressionQuality outputFormat:(NSString *) outputFormat
 {
 
     NSURL* _imageURL = [NSURL URLWithString: imageURL];
@@ -76,7 +76,11 @@
     UIImage *uiImage = [self thumbnailWithContentsOfURL:_imageURL maxPixelSize:maxSize];
     if(uiImage) {
         NSError *writeError = nil;
-        [UIImageJPEGRepresentation(uiImage, compressionQuality) writeToFile:toURL options:NSDataWritingAtomic error:&writeError];
+        if([outputFormat isEqualToString:@"PNG"]){
+            [UIImagePNGRepresentation(uiImage) writeToFile:toURL options:NSDataWritingAtomic error:&writeError];
+        } else {
+            [UIImageJPEGRepresentation(uiImage, compressionQuality) writeToFile:toURL options:NSDataWritingAtomic error:&writeError];
+        }
         if (writeError) {
             NSLog(@"Failed to write image: %@", writeError);
         }
@@ -117,10 +121,13 @@
         CGFloat size = [self getMaxSize: command];
 
         NSNumber* compressionPercent = nil;
-        if ([command.arguments count] == 2) {
+        NSString* outputFormat = nil;
+        if ([command.arguments count] == 3) {
             compressionPercent = [command.arguments objectAtIndex:2];
+            outputFormat = [command.arguments objectAtIndex:3];
         } else {
             compressionPercent = [command.arguments objectAtIndex:3];
+            outputFormat = [command.arguments objectAtIndex:4];
         }
         CGFloat compressionQuality = [compressionPercent floatValue] / 100;
 
@@ -131,7 +138,7 @@
         }
 
         [FileUtil createFileAtURL: targetURL];
-        [Thumbnail thumbnail:sourceURL size: size toURL:targetURL compression: compressionQuality];
+        [Thumbnail thumbnail:sourceURL size: size toURL:targetURL compression: compressionQuality outputFormat: outputFormat];
 
         CDVPluginResult* pluginResult = nil;
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK

--- a/src/windows/ThumbnailProxy.js
+++ b/src/windows/ThumbnailProxy.js
@@ -1,7 +1,5 @@
 /* global Windows, WinJS, MSApp */
 
-var utils = require('cordova/utils');
-
 var getFolderFromPathAsync = Windows.Storage.StorageFolder.getFolderFromPathAsync;
 var getFileFromPathAsync = Windows.Storage.StorageFile.getFileFromPathAsync;
 
@@ -30,13 +28,6 @@ var WinFS = function (name, root) {
         root.nativeURL = 'file://' + sanitize(this.winpath + root.fullPath).replace(':', '%3A');
     }
     WinFS.__super__.constructor.call(this, name, root);
-};
-
-utils.extend(WinFS, FileSystem);
-
-WinFS.prototype.__format__ = function (fullPath) {
-    var path = sanitize('/' + this.name + (fullPath[0] === '/' ? '' : '/') + FileSystem.encodeURIPath(fullPath));
-    return 'cdvfile://localhost' + path;
 };
 
 var AllFileSystems;

--- a/src/windows/ThumbnailProxy.js
+++ b/src/windows/ThumbnailProxy.js
@@ -1,0 +1,288 @@
+/* global Windows, WinJS, MSApp */
+
+var utils = require('cordova/utils');
+
+var getFolderFromPathAsync = Windows.Storage.StorageFolder.getFolderFromPathAsync;
+var getFileFromPathAsync = Windows.Storage.StorageFile.getFileFromPathAsync;
+
+
+function cordovaPathToNative(path) {
+    // turn / into \\
+    var cleanPath = path.replace(/\//g, '\\');
+    // turn  \\ into \
+    cleanPath = cleanPath.replace(/\\+/g, '\\');
+    return cleanPath;
+}
+
+function nativePathToCordova(path) {
+    var cleanPath = path.replace(/\\/g, '/');
+    return cleanPath;
+}
+
+var driveRE = new RegExp("^[/]*([A-Z]:)");
+
+var WinFS = function (name, root) {
+    this.winpath = root.winpath;
+    if (this.winpath && !/\/$/.test(this.winpath)) {
+        this.winpath += '/';
+    }
+    this.makeNativeURL = function (path) {
+        // CB-11848: This RE supposed to match all leading slashes in sanitized path.
+        // Removing leading slash to avoid duplicating because this.root.nativeURL already has trailing slash
+        var regLeadingSlashes = /^\/*/;
+        var sanitizedPath = sanitize(path.replace(':', '%3A')).replace(regLeadingSlashes, '');
+        return FileSystem.encodeURIPath(this.root.nativeURL + sanitizedPath);
+    };
+    root.fullPath = '/';
+    if (!root.nativeURL) {
+        root.nativeURL = 'file://' + sanitize(this.winpath + root.fullPath).replace(':', '%3A');
+    }
+    WinFS.__super__.constructor.call(this, name, root);
+};
+
+utils.extend(WinFS, FileSystem);
+
+WinFS.prototype.__format__ = function (fullPath) {
+    var path = sanitize('/' + this.name + (fullPath[0] === '/' ? '' : '/') + FileSystem.encodeURIPath(fullPath));
+    return 'cdvfile://localhost' + path;
+};
+
+var windowsPaths = {
+    dataDirectory: 'ms-appdata:///local/',
+    cacheDirectory: 'ms-appdata:///temp/',
+    tempDirectory: 'ms-appdata:///temp/',
+    syncedDataDirectory: 'ms-appdata:///roaming/',
+    applicationDirectory: 'ms-appx:///',
+    applicationStorageDirectory: 'ms-appx:///'
+};
+
+var AllFileSystems;
+
+function getAllFS() {
+    if (!AllFileSystems) {
+        AllFileSystems = {
+            'persistent':
+                Object.freeze(new WinFS('persistent', {
+                    name: 'persistent',
+                    nativeURL: 'ms-appdata:///local',
+                    winpath: nativePathToCordova(Windows.Storage.ApplicationData.current.localFolder.path)
+                })),
+            'temporary':
+                Object.freeze(new WinFS('temporary', {
+                    name: 'temporary',
+                    nativeURL: 'ms-appdata:///temp',
+                    winpath: nativePathToCordova(Windows.Storage.ApplicationData.current.temporaryFolder.path)
+                })),
+            'application':
+                Object.freeze(new WinFS('application', {
+                    name: 'application',
+                    nativeURL: 'ms-appx:///',
+                    winpath: nativePathToCordova(Windows.ApplicationModel.Package.current.installedLocation.path)
+                })),
+            'root':
+                Object.freeze(new WinFS('root', {
+                    name: 'root',
+                    // nativeURL: 'file:///'
+                    winpath: ''
+                }))
+        };
+    }
+    return AllFileSystems;
+}
+
+function sanitize(path) {
+    var slashesRE = new RegExp('/{2,}', 'g');
+    var components = path.replace(slashesRE, '/').split(/\/+/);
+    // Remove double dots, use old school array iteration instead of RegExp
+    // since it is impossible to debug them
+    for (var index = 0; index < components.length; ++index) {
+        if (components[index] === "..") {
+            components.splice(index, 1);
+            if (index > 0) {
+                // if we're not in the start of array then remove preceeding path component,
+                // In case if relative path points above the root directory, just ignore double dots
+                // See file.spec.111 should not traverse above above the root directory for test case
+                components.splice(index - 1, 1);
+                --index;
+            }
+        }
+    }
+    return components.join('/');
+}
+
+function getFilesystemFromPath(path) {
+    var res;
+    var allfs = getAllFS();
+    Object.keys(allfs).some(function (fsn) {
+        var fs = allfs[fsn];
+        if (path.indexOf(fs.winpath) === 0) {
+            res = fs;
+        }
+        return res;
+    });
+    return res;
+}
+
+
+var msapplhRE = new RegExp('^ms-appdata://localhost/');
+
+function pathFromURL(url) {
+    url = url.replace(msapplhRE, 'ms-appdata:///');
+    var path = decodeURIComponent(url);
+    // support for file name with parameters
+    if (/\?/g.test(path)) {
+        path = String(path).split("?")[0];
+    }
+    if (path.indexOf("file:/") === 0) {
+        if (path.indexOf("file://") !== 0) {
+            url = "file:///" + url.substr(6);
+        }
+    }
+
+    ['file://', 'ms-appdata:///', 'cdvfile://localhost/'].every(function (p) {
+        if (path.indexOf(p) !== 0)
+            return true;
+        var thirdSlash = path.indexOf("/", p.length);
+        if (thirdSlash < 0) {
+            path = "";
+        } else {
+            path = sanitize(path.substr(thirdSlash));
+        }
+    });
+
+    return path.replace(driveRE, '$1');
+}
+
+function getFilesystemFromURL(url) {
+    url = url.replace(msapplhRE, 'ms-appdata:///');
+    var res;
+    if (url.indexOf('file:/') === 0) {
+        res = getFilesystemFromPath(pathFromURL(url));
+    } else {
+        var allfs = getAllFS();
+        Object.keys(allfs).every(function (fsn) {
+            var fs = allfs[fsn];
+            if (url.indexOf(fs.root.nativeURL) === 0 ||
+                url.indexOf('cdvfile://localhost/' + fs.name + '/') === 0) {
+                res = fs;
+                return false;
+            }
+            return true;
+        });
+    }
+    return res;
+}
+
+function writeBlobAsync(storageFile, data, position) {
+    return storageFile.openAsync(Windows.Storage.FileAccessMode.readWrite)
+        .then(function (output) {
+            output.seek(position);
+            var dataSize = data.size;
+            var input = (data.detachStream || data.msDetachStream).call(data);
+
+            // Copy the stream from the blob to the File stream
+            return Windows.Storage.Streams.RandomAccessStream.copyAsync(input, output)
+                .then(function () {
+                    output.size = position + dataSize;
+                    return output.flushAsync().then(function () {
+                        input.close();
+                        output.close();
+
+                        return dataSize;
+                    });
+                });
+        });
+}
+
+function writeArrayBufferAsync(storageFile, data, position) {
+    return writeBlobAsync(storageFile, new Blob([data]), position); // eslint-disable-line no-undef
+}
+
+function makeThumbnail(win, fail, args) {
+    var srcPath, targetPath, maxPixelSize, compression, outputFormat;
+    if (args.length === 4) {
+        srcPath = args[0];
+        maxPixelSize = args[1];
+        compression = args[2];
+        outputFormat = args[3];
+    } else {
+        srcPath = args[0];
+        targetPath = args[1];
+        maxPixelSize = args[2];
+        compression = args[3];
+        outputFormat = args[4];
+    }
+    var thumbnailMode = Windows.Storage.FileProperties.ThumbnailMode.singleItem;
+    var thumbnailOptions = Windows.Storage.FileProperties.ThumbnailOptions.resizeThumbnail;
+    var sourceFs = getFilesystemFromURL(srcPath);
+    var sourcePath = pathFromURL(srcPath);
+    if (!sourceFs) {
+        fail({code: 3, message: "File access error"});
+        return;
+    }
+    var wSourcePath = cordovaPathToNative(sanitize(sourceFs.winpath + sourcePath));
+
+    var targetFs = getFilesystemFromURL(targetPath);
+    var path = pathFromURL(targetPath);
+    if (!targetFs) {
+        fail({code: 3, message: "File access error"});
+        return;
+    }
+    var completeTargetPath = sanitize(targetFs.winpath + path);
+    var targetFileName = completeTargetPath.substring(completeTargetPath.lastIndexOf('/') + 1);
+    var targetDirpath = completeTargetPath.substring(0, completeTargetPath.lastIndexOf('/'));
+    var wTargetDirPath = cordovaPathToNative(targetDirpath);
+
+    getFileFromPathAsync(wSourcePath).then(
+        function (storageFile) {
+            storageFile.getThumbnailAsync(thumbnailMode, maxPixelSize, thumbnailOptions).done(function (thumbnail) {
+                if (thumbnail) {
+                    var readSize = thumbnail.size;
+                    var buffer = new Windows.Storage.Streams.Buffer(readSize);
+                    var options = Windows.Storage.Streams.InputStreamOptions.None;
+                    thumbnail.readAsync(buffer, readSize, options).done(
+                        function (buffer) {
+                            getFolderFromPathAsync(wTargetDirPath).done(
+                                function (targetFolder) {
+                                    targetFolder.createFileAsync(targetFileName, Windows.Storage.CreationCollisionOption.openIfExists).done(
+                                        function (targetFile) {
+                                            var myArray = new Uint8Array(buffer.length);
+
+                                            var dataReader = Windows.Storage.Streams.DataReader.fromBuffer(buffer);
+                                            dataReader.readBytes(myArray)
+                                            dataReader.close();
+                                            writeArrayBufferAsync(targetFile, myArray.buffer, 0).done(
+                                                function (bytesWritten) {
+                                                    win(targetPath);
+                                                },
+                                                function () {
+                                                    fail({code: 5, message: "Failed to write out thumbnail to target path."});
+                                                }
+                                            );
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    )
+                } else {
+                    fail({code: 4, message: "Failed to create thumbnail."});
+                }
+            }, function (error) {
+                fail({code: 4, message: "Failed to create thumbnail."});
+            });
+        }, function () {
+            fail({code: 2, message: "File not found"});
+        }
+    );
+}
+
+
+module.exports = {
+
+    thumbnail: function (win, fail, args) {
+        makeThumbnail(win, fail, args);
+    },
+};
+
+require("cordova/exec/proxy").add("Thumbnails", module.exports);

--- a/src/windows/ThumbnailProxy.js
+++ b/src/windows/ThumbnailProxy.js
@@ -110,7 +110,7 @@ function getFilesystemFromPath(path) {
 
 var msapplhRE = new RegExp('^ms-appdata://localhost/');
 
-function (url) {
+function pathFromURL(url) {
     url = url.replace(msapplhRE, 'ms-appdata:///');
     var path = decodeURIComponent(url);
     // support for file name with parameters

--- a/src/windows/ThumbnailProxy.js
+++ b/src/windows/ThumbnailProxy.js
@@ -40,15 +40,6 @@ WinFS.prototype.__format__ = function (fullPath) {
     return 'cdvfile://localhost' + path;
 };
 
-var windowsPaths = {
-    dataDirectory: 'ms-appdata:///local/',
-    cacheDirectory: 'ms-appdata:///temp/',
-    tempDirectory: 'ms-appdata:///temp/',
-    syncedDataDirectory: 'ms-appdata:///roaming/',
-    applicationDirectory: 'ms-appx:///',
-    applicationStorageDirectory: 'ms-appx:///'
-};
-
 var AllFileSystems;
 
 function getAllFS() {

--- a/src/windows/ThumbnailProxy.js
+++ b/src/windows/ThumbnailProxy.js
@@ -27,7 +27,8 @@ var WinFS = function (name, root) {
     if (!root.nativeURL) {
         root.nativeURL = 'file://' + sanitize(this.winpath + root.fullPath).replace(':', '%3A');
     }
-    WinFS.__super__.constructor.call(this, name, root);
+    this.name = name;
+    this.root = root;
 };
 
 var AllFileSystems;

--- a/src/windows/ThumbnailProxy.js
+++ b/src/windows/ThumbnailProxy.js
@@ -15,8 +15,7 @@ function cordovaPathToNative(path) {
 }
 
 function nativePathToCordova(path) {
-    var cleanPath = path.replace(/\\/g, '/');
-    return cleanPath;
+    return path.replace(/\\/g, '/');
 }
 
 var driveRE = new RegExp("^[/]*([A-Z]:)");

--- a/src/windows/ThumbnailProxy.js
+++ b/src/windows/ThumbnailProxy.js
@@ -26,13 +26,6 @@ var WinFS = function (name, root) {
     if (this.winpath && !/\/$/.test(this.winpath)) {
         this.winpath += '/';
     }
-    this.makeNativeURL = function (path) {
-        // CB-11848: This RE supposed to match all leading slashes in sanitized path.
-        // Removing leading slash to avoid duplicating because this.root.nativeURL already has trailing slash
-        var regLeadingSlashes = /^\/*/;
-        var sanitizedPath = sanitize(path.replace(':', '%3A')).replace(regLeadingSlashes, '');
-        return FileSystem.encodeURIPath(this.root.nativeURL + sanitizedPath);
-    };
     root.fullPath = '/';
     if (!root.nativeURL) {
         root.nativeURL = 'file://' + sanitize(this.winpath + root.fullPath).replace(':', '%3A');
@@ -126,7 +119,7 @@ function getFilesystemFromPath(path) {
 
 var msapplhRE = new RegExp('^ms-appdata://localhost/');
 
-function pathFromURL(url) {
+function (url) {
     url = url.replace(msapplhRE, 'ms-appdata:///');
     var path = decodeURIComponent(url);
     // support for file name with parameters

--- a/src/windows/ThumbnailProxy.js
+++ b/src/windows/ThumbnailProxy.js
@@ -1,3 +1,24 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
 /* global Windows, WinJS, MSApp */
 
 var getFolderFromPathAsync = Windows.Storage.StorageFolder.getFolderFromPathAsync;

--- a/src/windows/ThumbnailProxy.js
+++ b/src/windows/ThumbnailProxy.js
@@ -233,28 +233,41 @@ function makeThumbnail(win, fail, args) {
                                                                     encoder.setSoftwareBitmap(softwareBitmap);
                                                                     encoder.flushAsync().done(
                                                                         function (result){
-                                                                             win(targetPath);
-                                                                        }
-                                                                    )
-                                                                }
-                                                            )
-                                                        }
-                                                    )
-                                                }
-                                            )
-                                        }
-                                    )
-                                }
-                            )
-                        }
-                    )
+                                                                            win(targetPath);
+                                                                        }, function (error) {
+                                                                            fail({
+                                                                                code: 4,
+                                                                                message: "Failed to create thumbnail."
+                                                                            });
+                                                                        })
+                                                                }, function (error) {
+                                                                    fail({
+                                                                        code: 10,
+                                                                        message: "Failed to create bitmap encoder."
+                                                                    });
+                                                                })
+                                                        }, function (error) {
+                                                            fail({code: 9, message: "Failed to open target file."});
+                                                        })
+                                                }, function (error) {
+                                                    fail({code: 8, message: "Failed to create target file."});
+                                                })
+                                        }, function (error) {
+                                            fail({code: 7, message: "Failed to get target folder."});
+                                        })
+                                }, function (error) {
+                                    fail({code: 6, message: "Failed to create software bitmap."});
+                                })
+                        }, function (error) {
+                            fail({code: 5, message: "Failed to create bitmap decoder."});
+                        })
                 } else {
                     fail({code: 4, message: "Failed to create thumbnail."});
                 }
             }, function (error) {
                 fail({code: 4, message: "Failed to create thumbnail."});
             });
-        }, function () {
+        }, function (error) {
             fail({code: 2, message: "File not found"});
         }
     );

--- a/www/thumbnail.js
+++ b/www/thumbnail.js
@@ -11,11 +11,23 @@ function options2Args(options) {
     if(!options.compression) {
         options.compression = 90;
     }
+    
+    if(!options.outputFormat && options.targetPath) {
+        var ext = options.targetPath.split(".").pop().lower()
+        if (ext === 'png'){
+            options.outputFormat = 'PNG';
+        } else if (ext === 'webp'){
+            options.outputFormat = 'WEBP'
+        } else {
+            options.outputFormat = 'JPG'
+        }
+        
+    }
 
     if (!options.targetPath) {
-        return [options.srcPath, options.maxPixelSize, options.compression];
+        return [options.srcPath, options.maxPixelSize, options.compression, "JPG"];
     } else {
-        return [options.srcPath, options.targetPath, options.maxPixelSize, options.compression];
+        return [options.srcPath, options.targetPath, options.maxPixelSize, options.compression, options.outputFormat];
     }
 }
 


### PR DESCRIPTION
The Windows code has some liberal copying from `cordova-plugin-file`'s FileProxy.js Windows code, so I could read files. The rest is pulled and adapted from C# examples.

Also made some changes to the basic functionality so we could actually specify what output format we wanted, rather than guessing based on the extension of the target path. And had to fix the iOS code so it would compile first.